### PR TITLE
Show not found users in slack response

### DIFF
--- a/src/main/java/ua/com/juja/microservices/teams/slackbot/exceptions/BaseBotException.java
+++ b/src/main/java/ua/com/juja/microservices/teams/slackbot/exceptions/BaseBotException.java
@@ -24,7 +24,4 @@ public class BaseBotException extends RuntimeException {
     public String getExceptionMessage() {
         return error.getExceptionMessage();
     }
-
-
-
 }

--- a/src/main/java/ua/com/juja/microservices/teams/slackbot/exceptions/BaseBotException.java
+++ b/src/main/java/ua/com/juja/microservices/teams/slackbot/exceptions/BaseBotException.java
@@ -21,8 +21,10 @@ public class BaseBotException extends RuntimeException {
         return error.getClientMessage();
     }
 
-    public ApiError getError() {
-        return error;
+    public String getExceptionMessage() {
+        return error.getExceptionMessage();
     }
+
+
 
 }

--- a/src/main/java/ua/com/juja/microservices/teams/slackbot/exceptions/ExceptionsHandler.java
+++ b/src/main/java/ua/com/juja/microservices/teams/slackbot/exceptions/ExceptionsHandler.java
@@ -44,16 +44,16 @@ public class ExceptionsHandler {
 
     @ExceptionHandler(UserExchangeException.class)
     public void handleUserExchangeException(UserExchangeException ex) {
-        sendErrorResponseAsRichMessage(new RichMessage(ex.getError().getExceptionMessage()));
+        sendErrorResponseAsRichMessage(new RichMessage(ex.getExceptionMessage()));
     }
 
     @ExceptionHandler(TeamExchangeException.class)
     public void handleTeamExchangeException(TeamExchangeException ex) {
         String message = ex.getMessage();
-        ApiError apiError = ex.getError();
-        if (apiError != null && apiError.getExceptionMessage().contains("#")) {
+        String exceptionMessage= ex.getExceptionMessage();
+        if (exceptionMessage != null && exceptionMessage.contains("#")) {
             try {
-                message = userService.replaceUuidsBySlackNamesInExceptionMessage(apiError.getExceptionMessage());
+                message = userService.replaceUuidsBySlackNamesInExceptionMessage(exceptionMessage);
             } catch (Exception e) {
                 log.warn("Nested exception : '{}'", e.getMessage());
             }

--- a/src/main/java/ua/com/juja/microservices/teams/slackbot/exceptions/ExceptionsHandler.java
+++ b/src/main/java/ua/com/juja/microservices/teams/slackbot/exceptions/ExceptionsHandler.java
@@ -44,7 +44,7 @@ public class ExceptionsHandler {
 
     @ExceptionHandler(UserExchangeException.class)
     public void handleUserExchangeException(UserExchangeException ex) {
-        sendErrorResponseAsRichMessage(new RichMessage(ex.getMessage()));
+        sendErrorResponseAsRichMessage(new RichMessage(ex.getError().getExceptionMessage()));
     }
 
     @ExceptionHandler(TeamExchangeException.class)

--- a/src/test/java/ua/com/juja/microservices/integration/TeamsSlackBotIntegrationTest.java
+++ b/src/test/java/ua/com/juja/microservices/integration/TeamsSlackBotIntegrationTest.java
@@ -286,7 +286,7 @@ public class TeamsSlackBotIntegrationTest {
         final List<User> usersInCommand = Arrays.asList(user1, user2, user3, user4);
         String responseUrl = "http://example.com";
         mockFailUsersServiceFindUsersBySlackNamesReturnsError(usersInCommand);
-        mockSlackResponseUrl(responseUrl, new RichMessage("Oops something went wrong :("));
+        mockSlackResponseUrl(responseUrl, new RichMessage("very big and scare error"));
 
         mvc.perform(MockMvcRequestBuilders.post(SlackUrlUtils.getUrlTemplate(teamsSlackbotActivateTeamUrl),
                 SlackUrlUtils.getUriVars("slashCommandToken", "/command", commandText, responseUrl))
@@ -544,7 +544,7 @@ public class TeamsSlackBotIntegrationTest {
         String responseUrl = "http://example.com";
         mockFailUsersServiceFindUsersBySlackNamesReturnsError(usersInCommand);
         mockSlackResponseUrl(responseUrl,
-                new RichMessage("Oops something went wrong :("));
+                new RichMessage("very big and scare error"));
 
         mvc.perform(MockMvcRequestBuilders.post(SlackUrlUtils.getUrlTemplate(teamsSlackbotGetTeamUrl),
                 SlackUrlUtils.getUriVars("slashCommandToken", "/command", commandText, responseUrl))

--- a/src/test/java/ua/com/juja/microservices/teams/slackbot/exceptions/ExceptionHandlerTest.java
+++ b/src/test/java/ua/com/juja/microservices/teams/slackbot/exceptions/ExceptionHandlerTest.java
@@ -125,7 +125,7 @@ public class ExceptionHandlerTest {
         verify(teamService).activateTeam(activateTeamCommandText);
         ArgumentCaptor<RichMessage> captor = ArgumentCaptor.forClass(RichMessage.class);
         verify(restTemplate).postForObject(eq(responseUrl), captor.capture(), eq(String.class));
-        assertTrue(captor.getValue().getText().contains(apiError.getClientMessage()));
+        assertTrue(captor.getValue().getText().contains(apiError.getExceptionMessage()));
         verifyNoMoreInteractions(teamService, restTemplate);
     }
 


### PR DESCRIPTION
#31
 new RichMessage(ex.getError().getExceptionMessage())
 instead of
 new RichMessage(ex.getMessage())